### PR TITLE
Fixed bounce of the hexes

### DIFF
--- a/lib/widgets/hexagon_button.dart
+++ b/lib/widgets/hexagon_button.dart
@@ -75,6 +75,15 @@ class _HexagonButtonState extends State<HexagonButton>
           });
         }
       },
+      onTapCancel: () {
+        if (widget.block.isEnabled) {
+          setState(() {
+            hexagonWidthAnimated *= 5;
+            textScale = 15;
+          });
+          widget.onClick();
+        }
+      },
       child: SizedBox(
         width: hexagonWidthFixed,
         child: Center(


### PR DESCRIPTION
Added onTapCancel in the GestureDetector. Now when the user go outside the hex, the onTapCancel is called.

Signed-off-by: Stefano Sidoni <oniryu95@yahoo.it>