### PR TITLE
Add dynamic level generation

### DIFF
--- a/lib/core/game_logic.dart
+++ b/lib/core/game_logic.dart
@@ -10,7 +10,7 @@ class GameLogic {
   late BlockGrid origin;
   late GridType type;
 
-  GameLogic(this.type, int width, int height) {
+  GameLogic(this.type, {int width = 4, int height = 4}) {
     origin = BlockGrid.buildRandom(width, height);
     calculateValues();
     initGame();
@@ -156,6 +156,6 @@ class GameLogic {
 }
 
 void main() {
-  GameLogic gameLogic = GameLogic(GridType.hexagon, 6, 6);
+  GameLogic gameLogic = GameLogic(GridType.hexagon, width: 5, height: 5);
   gameLogic.printGrid();
 }

--- a/lib/screens/level.dart
+++ b/lib/screens/level.dart
@@ -20,7 +20,7 @@ class Level extends StatefulWidget {
 }
 
 class _LevelState extends State<Level> with TickerProviderStateMixin {
-  GameLogic gameLogic = GameLogic(GridType.hexagon, 5, 8);
+  late GameLogic gameLogic;
 
   var animationTime = const Duration(milliseconds: 1000);
 
@@ -28,6 +28,14 @@ class _LevelState extends State<Level> with TickerProviderStateMixin {
       vsync: this, duration: const Duration(milliseconds: 300));
 
   bool completed = false;
+
+  @override
+  void initState() {
+    super.initState();
+    gameLogic = GameLogic(GridType.hexagon,
+        width: widget.currentTheme.levelDimension[0],
+        height: widget.currentTheme.levelDimension[1]);
+  }
 
   @override
   void dispose() {

--- a/lib/ui/hexagon_theme.dart
+++ b/lib/ui/hexagon_theme.dart
@@ -65,6 +65,7 @@ class PlanetTheme {
 
   late String difficult;
   late String gridMenu;
+  late List<int> levelDimension;
 
   PlanetTheme() {}
 
@@ -81,5 +82,6 @@ class PlanetTheme {
     background_path = theme["background_path"];
     difficult = key[0].toUpperCase() + key.substring(1);
     gridMenu = theme["grid"];
+    levelDimension = List<int>.from(theme["level_dimension"]);
   }
 }

--- a/resources/themes.json
+++ b/resources/themes.json
@@ -8,7 +8,8 @@
     "position": 0,
     "background_path": "images/background/mozilla_background_2.png",
     "planet_path" : "images/planets/mozilla_planet.png",
-    "grid" : "- 1 0 - \n 0 0 0 - \n- 0 0 - \n- 0 -  - "
+    "grid" : "- 1 0 - \n 0 0 0 - \n- 0 0 - \n- 0 -  - ",
+    "level_dimension" : [4,4]
   },
   "medium" : {
     "color_1"   : "FFFF75AD",
@@ -19,7 +20,8 @@
     "position": 1,
     "background_path": "images/background/pink_background.jpg",
     "planet_path" : "images/planets/pink_planet.png",
-    "grid" : "1 0 0 0 \n 0 - 0 - \n- 0 0 - \n0 - 0 - "
+    "grid" : "1 0 0 0 \n 0 - 0 - \n- 0 0 - \n0 - 0 - ",
+    "level_dimension" : [5,6]
   },
   "hard" : {
     "color_1"   : "FF2CE295",
@@ -30,19 +32,7 @@
     "position": 2,
     "background_path": "images/background/dino_background.jpg",
     "planet_path" : "images/planets/dino_planet.png",
-
-    "grid" : "1 0 0 0 \n 0 - 0 - \n0 0 0 0 \n0 0 0 - "
-  },
-  "secret" : {
-    "color_1"   : "FF3D26C1",
-    "color_2"   : "FFBF19E6",
-    "no_color"  : "FFD6D6D6",
-    "gradient_1": "FFA390F1",
-    "gradient_2": "FF6622BC",
-    "position": 3,
-    "background_path": "images/background/infinity_background.jpg",
-    "planet_path" : "images/planets/infinity_planet.png",
-
-    "grid" : "1 0 0 0 \n - 0 - - \n0 0 0 0 \n- 0 - - "
+    "grid" : "1 0 0 0 \n 0 - 0 - \n0 0 0 0 \n0 0 0 - ",
+    "level_dimension" : [6,8]
   }
 }

--- a/test/core_test.dart
+++ b/test/core_test.dart
@@ -8,7 +8,7 @@ import 'package:hexagon_glass/main.dart';
 
 void main() {
   test('Check game', () {
-    GameLogic game = GameLogic(GridType.hexagon, 4, 4);
+    GameLogic game = GameLogic(GridType.hexagon);
     for (int i = 0; i < game.nRows(); i++) {
       for (int j = 0; j < game.nColumns(); j++) {
         game.status.matrix[i][j].color = game.origin.matrix[i][j].color;
@@ -30,7 +30,7 @@ void main() {
   });
 
   test('Check uncompleted game', () {
-    GameLogic game = GameLogic(GridType.hexagon, 4, 4);
+    GameLogic game = GameLogic(GridType.hexagon);
     for (int i = 0; i < game.nRows(); i++) {
       for (int j = 0; j < game.nColumns(); j++) {
         game.status.matrix[i][j].color = game.origin.matrix[i][j].color;


### PR DESCRIPTION
Now every theme has its field about grid parameters. 
It's a `List<int>` with `[width as int, height as int]`.
`GameLogic` builds the grid from it.

Closes #12 
About the issuse #12 I changed the definition of `Easy`, `Medium`, `Hard`: every level has its parameters. 
So for now it doesn't exist a real difficulty, but every theme can have its own.